### PR TITLE
Memory leak due to a typo in the Remove method

### DIFF
--- a/src/com/xeio/MobMarkers/MobMarkers.as
+++ b/src/com/xeio/MobMarkers/MobMarkers.as
@@ -157,7 +157,7 @@ class MobMarkers
     private function Remove(dynel:Dynel)
     {
         Utils.Remove(m_dynels, dynel);
-        delete _root.waypoints.m_CurrentPFInterface.m_Waypoints[dynel.GetID().toString];
+        delete _root.waypoints.m_CurrentPFInterface.m_Waypoints[dynel.GetID().toString()];
         _root.waypoints.m_CurrentPFInterface.SignalWaypointRemoved.Emit(dynel.GetID());
     }
     


### PR DESCRIPTION
Waypoints are not removed properly, causing heavy lags and deteriorating performance after a while, especially in OD.